### PR TITLE
Implemented simulateUseItem in PlayerMock

### DIFF
--- a/src/main/java/be/seeseemelk/mockbukkit/block/data/BlockDataMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/data/BlockDataMock.java
@@ -1,6 +1,8 @@
 package be.seeseemelk.mockbukkit.block.data;
 
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
+import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import be.seeseemelk.mockbukkit.world.EnumInteractionResult;
 import com.destroystokyo.paper.MaterialTags;
 import com.google.common.base.Preconditions;
 import org.bukkit.Color;
@@ -16,6 +18,7 @@ import org.bukkit.block.PistonMoveReaction;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.structure.Mirror;
 import org.bukkit.block.structure.StructureRotation;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.VoxelShape;
 import org.jetbrains.annotations.NotNull;
@@ -455,6 +458,11 @@ public class BlockDataMock implements BlockData
 			return new SwitchMock(material);
 		}
 		return null;
+	}
+
+	public EnumInteractionResult use(PlayerMock playerMock, EquipmentSlot equipmentSlot)
+	{
+		throw new UnimplementedOperationException("BlockDataMock::use is not implemented for Material "+getMaterial());
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/block/data/BlockDataMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/data/BlockDataMock.java
@@ -460,7 +460,7 @@ public class BlockDataMock implements BlockData
 		return null;
 	}
 
-	public EnumInteractionResult use(PlayerMock playerMock, EquipmentSlot equipmentSlot)
+	public EnumInteractionResult simulateUse(PlayerMock playerMock, EquipmentSlot equipmentSlot)
 	{
 		throw new UnimplementedOperationException("BlockDataMock::use is not implemented for Material "+getMaterial());
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/BlockStateMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/BlockStateMock.java
@@ -458,7 +458,7 @@ public class BlockStateMock implements BlockState
 
 	public EnumInteractionResult simulateUse(PlayerMock playerMock, EquipmentSlot equipmentSlot) {
 		if (blockData instanceof BlockDataMock blockDataMock) {
-			return blockDataMock.use(playerMock, equipmentSlot);
+			return blockDataMock.simulateUse(playerMock, equipmentSlot);
 		}
 		throw new UnimplementedOperationException("BlockDataMock::use is not implemented in " + blockData.getClass().getName()+ " or overridden in " + this.getClass().getName());
 	}

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/BlockStateMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/BlockStateMock.java
@@ -3,7 +3,9 @@ package be.seeseemelk.mockbukkit.block.state;
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 import be.seeseemelk.mockbukkit.block.BlockMock;
 import be.seeseemelk.mockbukkit.block.data.BlockDataMock;
+import be.seeseemelk.mockbukkit.entity.PlayerMock;
 import be.seeseemelk.mockbukkit.metadata.MetadataTable;
+import be.seeseemelk.mockbukkit.world.EnumInteractionResult;
 import com.destroystokyo.paper.MaterialTags;
 import com.google.common.base.Preconditions;
 import org.bukkit.Chunk;
@@ -15,6 +17,7 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.Entity;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.metadata.MetadataValue;
 import org.bukkit.plugin.Plugin;
@@ -420,65 +423,44 @@ public class BlockStateMock implements BlockState
 		{
 			return new SkullMock(block);
 		}
-		switch (block.getType())
+		return switch (block.getType())
 		{
-		case STRUCTURE_BLOCK:
-			return new StructureMock(block);
-		case SMOKER:
-			return new SmokerMock(block);
-		case END_GATEWAY:
-			return new EndGatewayMock(block);
-		case SCULK_CATALYST:
-			return new SculkCatalystMock(block);
-		case SCULK_SHRIEKER:
-			return new SculkShriekerMock(block);
-		case SCULK_SENSOR:
-			return new SculkSensorMock(block);
-		case BEACON:
-			return new BeaconMock(block);
-		case BEEHIVE:
-			return new BeehiveMock(block);
-		case BREWING_STAND:
-			return new BrewingStandMock(block);
-		case BLAST_FURNACE:
-			return new BlastFurnaceMock(block);
-		case COMPARATOR:
-			return new ComparatorMock(block);
-		case CONDUIT:
-			return new ConduitMock(block);
-		case ENCHANTING_TABLE:
-			return new EnchantingTableMock(block);
-		case JIGSAW:
-			return new JigsawMock(block);
-		case JUKEBOX:
-			return new JukeboxMock(block);
-		case SPAWNER:
-			return new CreatureSpawnerMock(block);
-		case DAYLIGHT_DETECTOR:
-			return new DaylightDetectorMock(block);
-		case COMMAND_BLOCK, CHAIN_COMMAND_BLOCK, REPEATING_COMMAND_BLOCK:
-			return new CommandBlockMock(block);
-		case CAMPFIRE, SOUL_CAMPFIRE:
-			return new CampfireMock(block);
-		case BELL:
-			return new BellMock(block);
-		case LECTERN:
-			return new LecternMock(block);
-		case HOPPER:
-			return new HopperMock(block);
-		case BARREL:
-			return new BarrelMock(block);
-		case DISPENSER:
-			return new DispenserMock(block);
-		case DROPPER:
-			return new DropperMock(block);
-		case CHEST, TRAPPED_CHEST:
-			return new ChestMock(block);
-		case ENDER_CHEST:
-			return new EnderChestMock(block);
-		default:
-			return new BlockStateMock(block);
+			case STRUCTURE_BLOCK -> new StructureMock(block);
+			case SMOKER -> new SmokerMock(block);
+			case END_GATEWAY -> new EndGatewayMock(block);
+			case SCULK_CATALYST -> new SculkCatalystMock(block);
+			case SCULK_SHRIEKER -> new SculkShriekerMock(block);
+			case SCULK_SENSOR -> new SculkSensorMock(block);
+			case BEACON -> new BeaconMock(block);
+			case BEEHIVE -> new BeehiveMock(block);
+			case BREWING_STAND -> new BrewingStandMock(block);
+			case BLAST_FURNACE -> new BlastFurnaceMock(block);
+			case COMPARATOR -> new ComparatorMock(block);
+			case CONDUIT -> new ConduitMock(block);
+			case ENCHANTING_TABLE -> new EnchantingTableMock(block);
+			case JIGSAW -> new JigsawMock(block);
+			case JUKEBOX -> new JukeboxMock(block);
+			case SPAWNER -> new CreatureSpawnerMock(block);
+			case DAYLIGHT_DETECTOR -> new DaylightDetectorMock(block);
+			case COMMAND_BLOCK, CHAIN_COMMAND_BLOCK, REPEATING_COMMAND_BLOCK -> new CommandBlockMock(block);
+			case CAMPFIRE, SOUL_CAMPFIRE -> new CampfireMock(block);
+			case BELL -> new BellMock(block);
+			case LECTERN -> new LecternMock(block);
+			case HOPPER -> new HopperMock(block);
+			case BARREL -> new BarrelMock(block);
+			case DISPENSER -> new DispenserMock(block);
+			case DROPPER -> new DropperMock(block);
+			case CHEST, TRAPPED_CHEST -> new ChestMock(block);
+			case ENDER_CHEST -> new EnderChestMock(block);
+			default -> new BlockStateMock(block);
+		};
+	}
+
+	public EnumInteractionResult simulateUse(PlayerMock playerMock, EquipmentSlot equipmentSlot) {
+		if (blockData instanceof BlockDataMock blockDataMock) {
+			return blockDataMock.use(playerMock, equipmentSlot);
 		}
+		throw new UnimplementedOperationException("BlockDataMock::use is not implemented in " + blockData.getClass().getName()+ " or overridden in " + this.getClass().getName());
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/block/state/ContainerMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/block/state/ContainerMock.java
@@ -1,12 +1,15 @@
 package be.seeseemelk.mockbukkit.block.state;
 
+import be.seeseemelk.mockbukkit.entity.PlayerMock;
 import be.seeseemelk.mockbukkit.inventory.InventoryMock;
+import be.seeseemelk.mockbukkit.world.EnumInteractionResult;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Container;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.Inventory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -119,6 +122,15 @@ public abstract class ContainerMock extends TileStateMock implements Container
 	public @NotNull Inventory getSnapshotInventory()
 	{
 		return ((InventoryMock) this.inventory).getSnapshot();
+	}
+
+	@Override
+	public EnumInteractionResult simulateUse(PlayerMock playerMock, EquipmentSlot equipmentSlot)
+	{
+		if (inventory != null) {
+			playerMock.openInventory(inventory);
+		}
+		return EnumInteractionResult.CONSUME;
 	}
 
 }

--- a/src/main/java/be/seeseemelk/mockbukkit/inventory/ItemStackMock.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/inventory/ItemStackMock.java
@@ -1,12 +1,17 @@
 package be.seeseemelk.mockbukkit.inventory;
 
+import be.seeseemelk.mockbukkit.UnimplementedOperationException;
+import be.seeseemelk.mockbukkit.entity.PlayerMock;
 import be.seeseemelk.mockbukkit.inventory.meta.ItemMetaMock;
+import be.seeseemelk.mockbukkit.world.EnumInteractionResult;
 import com.google.common.base.Preconditions;
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
 import org.bukkit.enchantments.Enchantment;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.ItemType;
@@ -248,6 +253,10 @@ public class ItemStackMock extends ItemStack
 			result.setDurability(damage);
 		}
 		return result;
+	}
+
+	public EnumInteractionResult simulateUse(PlayerMock playerMock, Location clickedPos, EquipmentSlot hand) {
+		throw new UnimplementedOperationException();
 	}
 
 	private static void handleMetaForDeserialization(@NotNull Map<String, Object> args, int version, ItemStack result)

--- a/src/main/java/be/seeseemelk/mockbukkit/world/EnumInteractionResult.java
+++ b/src/main/java/be/seeseemelk/mockbukkit/world/EnumInteractionResult.java
@@ -1,0 +1,28 @@
+package be.seeseemelk.mockbukkit.world;
+
+public enum EnumInteractionResult {
+	SUCCESS,
+	CONSUME,
+	CONSUME_PARTIAL,
+	PASS,
+	FAIL;
+
+	private EnumInteractionResult() {
+	}
+
+	public boolean consumesAction() {
+		return this == SUCCESS || this == CONSUME || this == CONSUME_PARTIAL;
+	}
+
+	public boolean shouldSwing() {
+		return this == SUCCESS;
+	}
+
+	public boolean shouldAwardStats() {
+		return this == SUCCESS || this == CONSUME;
+	}
+
+	public static EnumInteractionResult sidedSuccess(boolean var0) {
+		return var0 ? SUCCESS : CONSUME;
+	}
+}

--- a/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
+++ b/src/test/java/be/seeseemelk/mockbukkit/entity/PlayerMockTest.java
@@ -4,6 +4,7 @@ import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.MockPlugin;
 import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.TestPlugin;
+import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 import be.seeseemelk.mockbukkit.WorldMock;
 import be.seeseemelk.mockbukkit.block.BlockMock;
 import be.seeseemelk.mockbukkit.block.data.BlockDataMock;
@@ -36,10 +37,12 @@ import org.bukkit.SoundCategory;
 import org.bukkit.World;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
@@ -55,6 +58,7 @@ import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.PlayerChangedWorldEvent;
 import org.bukkit.event.player.PlayerExpChangeEvent;
 import org.bukkit.event.player.PlayerExpCooldownChangeEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerKickEvent;
@@ -2462,6 +2466,117 @@ class PlayerMockTest
 		player.setPlayerProfile(profile);
 
 		assertEquals(profile, player.getPlayerProfile());
+	}
+
+	@Test
+	void testPlayerInteractEvent_air() {
+		player.setGameMode(GameMode.SURVIVAL);
+		player.setItemInHand(null);
+
+		Location location = new Location(player.getWorld(), 0, 0, 0);
+		PlayerInteractEvent event = player.simulateUseItemOn(location, BlockFace.SELF, EquipmentSlot.HAND);
+
+		assertNotNull(event);
+		server.getPluginManager().assertEventFired(PlayerInteractEvent.class);
+		player.assertInventoryView(InventoryType.CRAFTING);
+	}
+
+	@Test
+	void testPlayerInteractEvent_openChest() {
+		player.setGameMode(GameMode.SURVIVAL);
+		player.setItemInHand(null);
+
+		BlockMock block = player.getWorld().getBlockAt(0, 0, 0);
+		block.setType(Material.CHEST);
+		PlayerInteractEvent event = player.simulateUseItemOn(block.getLocation(), BlockFace.SELF, EquipmentSlot.HAND);
+
+		assertNotNull(event);
+		server.getPluginManager().assertEventFired(PlayerInteractEvent.class);
+		player.assertInventoryView(InventoryType.CHEST);
+	}
+
+	@Test
+	void testPlayerInteractEvent_spectatorOpenChest() {
+		player.setGameMode(GameMode.SPECTATOR);
+		player.setItemInHand(null);
+
+		BlockMock block = player.getWorld().getBlockAt(0, 0, 0);
+		block.setType(Material.CHEST);
+		PlayerInteractEvent event = player.simulateUseItemOn(block.getLocation(), BlockFace.SELF, EquipmentSlot.HAND);
+
+		assertNotNull(event);
+		server.getPluginManager().assertEventFired(PlayerInteractEvent.class);
+		player.assertInventoryView(InventoryType.CHEST);
+	}
+
+	@Test
+	void testPlayerInteractEvent_spectatorFailInteract() {
+		player.setGameMode(GameMode.SPECTATOR);
+		player.setItemInHand(null);
+
+		BlockMock block = player.getWorld().getBlockAt(0, 0, 0);
+		block.setType(Material.OAK_DOOR);
+		PlayerInteractEvent event = player.simulateUseItemOn(block.getLocation(), BlockFace.SELF, EquipmentSlot.HAND);
+
+		assertNotNull(event);
+		assertEquals(event.useInteractedBlock(), Event.Result.DENY);
+		server.getPluginManager().assertEventFired(PlayerInteractEvent.class);
+	}
+
+	@Test
+	void testPlayerInteractEvent_sneakingWithNoItem() {
+		player.setGameMode(GameMode.SURVIVAL);
+		player.setSneaking(true);
+		player.setItemInHand(null);
+
+		BlockMock block = player.getWorld().getBlockAt(0, 0, 0);
+		block.setType(Material.CHEST);
+		PlayerInteractEvent event = player.simulateUseItemOn(block.getLocation(), BlockFace.SELF, EquipmentSlot.HAND);
+
+		assertNotNull(event);
+		server.getPluginManager().assertEventFired(PlayerInteractEvent.class);
+		player.assertInventoryView(InventoryType.CHEST);
+	}
+
+	@Test
+	void testPlayerInteractEvent_sneakingWithItem() {
+		player.setGameMode(GameMode.SURVIVAL);
+		player.setSneaking(true);
+		player.setItemInHand(ItemStackMock.of(Material.CHEST));
+
+		BlockMock block = player.getWorld().getBlockAt(0, 0, 0);
+		block.setType(Material.CHEST);
+
+		// We don't care if the item isn't implemented here since we're just checking if the Chest inventory doesn't open
+		try {
+			player.simulateUseItemOn(block.getLocation(), BlockFace.SELF, EquipmentSlot.HAND);
+		} catch (UnimplementedOperationException ignored) {}
+
+		server.getPluginManager().assertEventFired(PlayerInteractEvent.class);
+		player.assertInventoryView(InventoryType.CRAFTING);
+	}
+
+	@Test
+	void testPlayerInteractEvent_cancelled() {
+		TestPlugin plugin = MockBukkit.load(TestPlugin.class);
+		Bukkit.getPluginManager().registerEvents(new Listener()
+		{
+			@EventHandler
+			public void onPlayerInteract(@NotNull PlayerInteractEvent event)
+			{
+				event.setCancelled(true);
+			}
+		}, plugin);
+
+		player.setItemInHand(null);
+
+		BlockMock block = player.getWorld().getBlockAt(0, 0, 0);
+		block.setType(Material.CHEST);
+		PlayerInteractEvent event = player.simulateUseItemOn(block.getLocation(), BlockFace.SELF, EquipmentSlot.HAND);
+
+		assertNotNull(event);
+		server.getPluginManager().assertEventFired(PlayerInteractEvent.class);
+		player.assertInventoryView(InventoryType.CRAFTING);
 	}
 
 }


### PR DESCRIPTION
# Description
Add simulateUseItem to PlayerMock
Currently only has implementations for opening Containers

The current state can be used to test plugins that manipulate the Inventory and also to test PlayerInteractEvents that cancel the Event (Since the ItemStack simulateUse isn't implemented yet) 

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Code follows existing style.
- [x] Unit tests added (if applicable).
